### PR TITLE
Fix deployment script to upload tfvars to azure

### DIFF
--- a/install_scripts/deploy_multitenant_api_with_terraform.sh
+++ b/install_scripts/deploy_multitenant_api_with_terraform.sh
@@ -265,7 +265,7 @@ while IFS='=' read -r name value ; do
         # Extract the variable name without the TF_VAR_ prefix
         var_name=${name#TF_VAR_}
         # Write the variable to the tfvars file
-        echo "$var_name = \"$value\"" >> "$output_file"
+        echo "$var_name=\"$value\"" >> "$output_file"
     fi
 done < <(env)
 


### PR DESCRIPTION
Deploy script update to save all environment variables starting with `TF_VAR_` to a terraform.tfvars file and upload it to azure client storage account.